### PR TITLE
make_kwd fails to save JSON info when fs obtained from file

### DIFF
--- a/klusta_pipeline/make_kwd.py
+++ b/klusta_pipeline/make_kwd.py
@@ -75,6 +75,7 @@ def main():
             assert interval is None or interval == rec['interval'], "intervals don't match between all the recordings... something seems wrong"
             interval = rec['interval']
         fs = 1.0 / interval
+        fs = fs.tolist()
     else:
         fs = args.fs
 


### PR DESCRIPTION
When obtaining sampling frequency from file, saves the sampling frequency as python list and not numpy array.  This fixes an error that occurs when saving recording info to JSON, due to numpy arrays being not serializable.

I tested this on some of my data and runs to completion. 

Here's the traceback of the original error:
Traceback (most recent call last):
  File "/home/btheilma/.conda/envs/klusta_pipeline/bin/make_kwd", line 9, in <module>
    load_entry_point('klusta-pipeline==0.0.2', 'console_scripts', 'make_kwd')()
  File "/usr/local/home/btheilma/kkpipeline_gentnerlab/klusta-pipeline/klusta_pipeline/make_kwd.py", line 99, in main
    save_info(dest,info)
  File "/usr/local/home/btheilma/kkpipeline_gentnerlab/klusta-pipeline/klusta_pipeline/dataio.py", line 129, in save_info
    json.dump(info,f,indent=4,sort_keys=True)
  File "/home/btheilma/.conda/envs/klusta_pipeline/lib/python2.7/json/__init__.py", line 189, in dump
    for chunk in iterable:
  File "/home/btheilma/.conda/envs/klusta_pipeline/lib/python2.7/json/encoder.py", line 434, in _iterencode
    for chunk in _iterencode_dict(o, _current_indent_level):
  File "/home/btheilma/.conda/envs/klusta_pipeline/lib/python2.7/json/encoder.py", line 408, in _iterencode_dict
    for chunk in chunks:
  File "/home/btheilma/.conda/envs/klusta_pipeline/lib/python2.7/json/encoder.py", line 408, in _iterencode_dict
    for chunk in chunks:
  File "/home/btheilma/.conda/envs/klusta_pipeline/lib/python2.7/json/encoder.py", line 442, in _iterencode
    o = _default(o)
  File "/home/btheilma/.conda/envs/klusta_pipeline/lib/python2.7/json/encoder.py", line 184, in default
    raise TypeError(repr(o) + " is not JSON serializable")
TypeError: array([ 31250.]) is not JSON serializable