### PR TITLE
removed reference to args.fs instead of fs

### DIFF
--- a/klusta_pipeline/make_kwd.py
+++ b/klusta_pipeline/make_kwd.py
@@ -72,10 +72,9 @@ def main():
     if args.fs is None:
         interval = None
         for rec in mat_data:
-            assert interval is None or interval == rec['interval'], "intervals don't match between all the recordings... something seems wrong"
-            interval = rec['interval']
+            assert interval is None or interval == rec['interval'][0], "intervals don't match between all the recordings... something seems wrong"
+            interval = rec['interval'][0]
         fs = 1.0 / interval
-        fs = fs.tolist()
     else:
         fs = args.fs
 
@@ -92,7 +91,7 @@ def main():
     for import_file in import_list:
         recordings = load_recordings(import_file,chans)
         for r in recordings:
-            rec = realign(r,chans,args.fs,args.realignment)
+            rec = realign(r,chans,fs,args.realignment)
             rec['data'] -= rec['data'].mean(axis=0)
             rec_list.append(rec)
         


### PR DESCRIPTION

Traceback (most recent call last):
  File "/usr/local/anaconda/bin/make_kwd", line 9, in <module>
    load_entry_point('klusta-pipeline==0.0.2', 'console_scripts', 'make_kwd')()
  File "/usr/local/home/mthielk/GitHub/klusta-pipeline/klusta_pipeline/make_kwd.py", line 95, in main
    rec = realign(r,chans,args.fs,args.realignment)
  File "/usr/local/home/mthielk/GitHub/klusta-pipeline/klusta_pipeline/utils.py", line 205, in realign
    rec['data'] = realign_methods[method](r, chans, fs, start, stop)
  File "/usr/local/home/mthielk/GitHub/klusta-pipeline/klusta_pipeline/utils.py", line 157, in spline_realign
    t_new = np.arange(start,stop,1.0/fs)
TypeError: unsupported operand type(s) for /: 'float' and 'NoneType'

removed reference to args.fs instead of fs