### PR TITLE
Fixed syntax errors due to extra copies of `save_parameters`

### DIFF
--- a/klusta_pipeline/make_kwd.py
+++ b/klusta_pipeline/make_kwd.py
@@ -99,11 +99,6 @@ def main():
     }
     save_parameters(info['params'],dest)
     
-    }
-    save_parameters(info['params'],dest)
-    }
-    save_parameters(info['params'],dest)
-    
     rec_list = []
     # print import_list
     for import_file in import_list:


### PR DESCRIPTION
Should be pretty self-explanatory.