### PR TITLE
added geometry of probe NN A1x32-Poly3-xmm-25s; added port-headstage …

### DIFF
--- a/klusta_pipeline/maps.py
+++ b/klusta_pipeline/maps.py
@@ -1,3 +1,30 @@
+import numpy as np
+
+#applies the transformation of sites to headstage introduced by an adapter
+def apply_adapter(a_port_site, adapter):
+    '''
+    a_port_site: a dictionary with port: site (mapping channels in a headstage to ports in a recording system)
+    adapter: n_site x 2 numpy array
+            col 0: site in headstage end
+            col 1: site in porbe end
+    retunrs: new dictionary with port: mapped_site, where mapped_site is the probe site that connects to that channel instead of site
+    '''
+    new_port_site = {port : adapter[adapter[:, 1] == site][0, 0] for port, site in a_port_site.iteritems()}
+    return new_port_site
+
+# n_site x 2 numpy array
+# col 0: site in headstage end
+# col 1: site in porbe end
+site_headstage = {
+    'A32-HST32V': np.transpose(np.array([[11, 9, 7, 5, 3, 2, 6, 8, 10, 12,
+                      1, 4, 13, 14, 15, 16, 
+                      26, 24, 20, 19, 18, 17, 
+                      32, 30, 31, 28, 29, 27, 25, 22, 23, 21], 
+                     [1, 2, 3, 4, 6, 8, 10, 12, 14, 16, 
+                      5, 7, 9, 11, 13, 15,
+                      21, 23, 25, 27, 29, 31,
+                      17, 18, 19, 20, 22, 24, 26, 28, 30, 32]], dtype=np.int)
+    )}
 
 # dictionary yields port:site
 port_site = {
@@ -39,3 +66,9 @@ port_site = {
 port_site['ibon32'] = port_site['paukstis32']
 port_site['bodegh16'] = {'Port_%d' % (i+1) : i+1 for i in range(16) }
 port_site['burung16'] = port_site['bodegh16']
+
+# Burung system with 32 channels trhough amps 2, 3, with no adapter
+port_site['burung32'] = {'Port_%d' % (i+1+16) : i+1 for i in range(32)} 
+
+# Buring system with the A32 adapter for neuronexus probes
+port_site['burung32-A32-HST32V'] = apply_adapter(port_site['burung32'], site_headstage['A32-HST32V'])

--- a/klusta_pipeline/probe.py
+++ b/klusta_pipeline/probe.py
@@ -56,6 +56,52 @@ def get_channel_groups(probe,s):
             }
         }
 
+	# probes A1x32-Poly3-xmm-25s-yyy
+	elif 'A1x32-Poly3' in probe and '25s' in probe:
+        channel_groups = {
+            # Shank index.
+            0: {   
+                # List of channels to keep for spike detection.
+                'channels': s.values(),
+
+                # 2D positions of the channels
+                'geometry': {
+                    s[17]: (18, 275), # column 1
+                    s[16]: (18, 250), 
+                    s[18]: (18, 225),
+                    s[15]: (18, 200),
+                    s[19]: (18, 175),
+                    s[14]: (18, 150),
+                    s[20]: (18, 125),
+                    s[13]: (18, 100),
+                    s[21]: (18, 75),
+                    s[12]: (18, 50),
+                    s[22]: (18, 25),
+                    s[11]: (18, 0), 
+                    s[10]: (0, 262), # column 0
+                    s[9]: (0, 237), 
+                    s[8]: (0, 212), 
+                    s[7]: (0, 187), 
+                    s[6]: (0, 162), 
+                    s[5]: (0, 137), 
+                    s[4]: (0, 112), 
+                    s[3]: (0, 87), 
+                    s[2]: (0, 62),  
+                    s[1]: (0, 37),   
+                    s[23]: (36, 262), # column 3
+                    s[24]: (36, 237), 
+                    s[25]: (36, 212), 
+                    s[26]: (36, 187), 
+                    s[27]: (36, 162), 
+                    s[28]: (36, 137), 
+                    s[29]: (36, 112), 
+                    s[30]: (36, 87), 
+                    s[31]: (36, 62),  
+                    s[32]: (36, 37)
+                }
+            }
+        }
+
     elif probe=='A1x16-5mm-50':
         channel_groups = {
             # Shank index.


### PR DESCRIPTION
Trivial change in probe.py with the geometry of NN Poly3 with 25um pitch (A1x32-Poly3-xx-25s-yy).

In maps.py, I added the port-site mapping of burung with 32 channels through amps 2 and 3. This port-site mapping actually describes the mapping of the ports in the recording system to the channels in the headstage (typycally sites).

If an adapter is added, it is described by an array (col0=headstage end, col1=probe end).

Function apply_adapter takes in a port-site mapping and an adapter, and remaps the site that corresponds to each port.

This should add a bit of modularity, if in some future we will have other systems, headstages and adapters.

todo/todiscuss: allow probe files and adapters to be entered as files? (systems should be stable over time and we don't want anyone to change the mappings without going through a pull request, but probes and adapters can be more volatile, specially in debugging phases).